### PR TITLE
Prevent build fail when a navbar is not provided on header

### DIFF
--- a/src/components/organisms/Header/Header.js
+++ b/src/components/organisms/Header/Header.js
@@ -77,15 +77,16 @@ const Header = props => {
   `)
 
   const header = data.header.nodes.find(item => item.id === props.contentfulId)
-  const navigationLinks = header.navBar.navigationLinks.map(item => {
+  const navBar = header.navBar ? header.navBar : { navigationLinks: [], mainIcon: null }
+  const navigationLinks = navBar.navigationLinks.map(item => {
     return { caption: item.caption, slug: item.to.slug }
   })
   const languageOptions = header.languageOptions.map(item => {
     return { text: item.name, value: item.locale }
   })
   const actionImage = {
-    imageUrl: header.navBar.mainIcon.icon.file.url,
-    slug: header.navBar.mainIcon.to.slug,
+    imageUrl: navBar.mainIcon ? navBar.mainIcon.icon.file.url : null,
+    slug: navBar.mainIcon ? navBar.mainIcon.to.slug : null,
   }
   const optionalStyles = JSON.parse(header.styles.internal.content)
   const styles = overrideStyle(defaultStyles, optionalStyles)


### PR DESCRIPTION
Hi team, this is a quick PR. I noticed a build failed due to a null navbar. This fixes that issue