### PR TITLE
Www 89 improve card holder

### DIFF
--- a/src/components/molecules/ImageCard/ImageCard.js
+++ b/src/components/molecules/ImageCard/ImageCard.js
@@ -16,9 +16,6 @@ const useStyles = props =>
     active: {
       background: getColor(props.styles.active.background),
       color: getColor(props.styles.active.color),
-      h6: {
-        color: getColor(props.styles.active.color),
-      }
     }
   }))
 

--- a/src/components/molecules/ImageCard/ImageCard.js
+++ b/src/components/molecules/ImageCard/ImageCard.js
@@ -16,31 +16,33 @@ const useStyles = props =>
     active: {
       background: getColor(props.styles.active.background),
       color: getColor(props.styles.active.color),
-    }
+    },
   }))
 
 const ImageCard = props => {
   const styles = overrideStyle(defaultStyles, props.optionalStyles)
 
   const classes = useStyles({ styles })()
-  const [hover, sethover] = useState(false);
+  const [hover, sethover] = useState(false)
   return (
     <Card className={classes.root}>
       <CardActionArea>
         <CardMedia className={classes.img} image={`https://${props.imgUrl}`} title={props.imgTitle} />
-        {hover ?
-          <CardContent onMouseOver={ ()=> sethover(true)}
-          onMouseOut={()=>sethover(false)}
-          className={classes.active}>
-          <Typography variant="h6" {...styles.text.active}>
-            {props.title}
-          </Typography>
-          <Typography variant="body2" component="p" {...styles.text.p}>
-            {props.body}
-          </Typography>
-        </CardContent> :
-          <CardContent onMouseOver={()=>sethover(true)}
-          onMouseOut={()=>sethover(false)}>
+        {hover ? (
+          <CardContent
+            onMouseOver={() => sethover(true)}
+            onMouseOut={() => sethover(false)}
+            className={classes.active}
+          >
+            <Typography variant="h6" {...styles.text.active}>
+              {props.title}
+            </Typography>
+            <Typography variant="body2" component="p" {...styles.text.p}>
+              {props.body}
+            </Typography>
+          </CardContent>
+        ) : (
+          <CardContent onMouseOver={() => sethover(true)} onMouseOut={() => sethover(false)}>
             <Typography variant="h6" {...styles.text.h6}>
               {props.title}
             </Typography>
@@ -48,7 +50,7 @@ const ImageCard = props => {
               {props.body}
             </Typography>
           </CardContent>
-        }
+        )}
       </CardActionArea>
     </Card>
   )

--- a/src/components/molecules/ImageCard/ImageCard.js
+++ b/src/components/molecules/ImageCard/ImageCard.js
@@ -24,13 +24,16 @@ const ImageCard = props => {
 
   const classes = useStyles({ styles })()
   const [hover, sethover] = useState(false)
+
   return (
     <Card className={classes.root}>
       <CardActionArea>
         <CardMedia className={classes.img} image={`https://${props.imgUrl}`} title={props.imgTitle} />
         {hover ? (
           <CardContent
+            onFocus
             onMouseOver={() => sethover(true)}
+            onBlur
             onMouseOut={() => sethover(false)}
             className={classes.active}
           >
@@ -42,7 +45,7 @@ const ImageCard = props => {
             </Typography>
           </CardContent>
         ) : (
-          <CardContent onMouseOver={() => sethover(true)} onMouseOut={() => sethover(false)}>
+          <CardContent onFocus onMouseOver={() => sethover(true)} onBlur onMouseOut={() => sethover(false)}>
             <Typography variant="h6" {...styles.text.h6}>
               {props.title}
             </Typography>

--- a/src/components/molecules/ImageCard/ImageCard.js
+++ b/src/components/molecules/ImageCard/ImageCard.js
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState } from "react"
 import defaultStyles from "./defaultStyles"
 import { getColor } from "../../../maps/colorMap"
 import { makeStyles } from "@material-ui/core/styles"
@@ -13,25 +13,45 @@ const useStyles = props =>
       maxWidth: props.styles.root.maxWidth,
     },
     img: props.styles.img,
+    active: {
+      background: getColor(props.styles.active.background),
+      color: getColor(props.styles.active.color),
+      h6: {
+        color: getColor(props.styles.active.color),
+      }
+    }
   }))
 
 const ImageCard = props => {
   const styles = overrideStyle(defaultStyles, props.optionalStyles)
 
   const classes = useStyles({ styles })()
-
+  const [hover, sethover] = useState(false);
   return (
     <Card className={classes.root}>
       <CardActionArea>
         <CardMedia className={classes.img} image={`https://${props.imgUrl}`} title={props.imgTitle} />
-        <CardContent>
-          <Typography variant="h6" {...styles.text.h6}>
+        {hover ?
+          <CardContent onMouseOver={ ()=> sethover(true)}
+          onMouseOut={()=>sethover(false)}
+          className={classes.active}>
+          <Typography variant="h6" {...styles.text.active}>
             {props.title}
           </Typography>
           <Typography variant="body2" component="p" {...styles.text.p}>
             {props.body}
           </Typography>
-        </CardContent>
+        </CardContent> :
+          <CardContent onMouseOver={()=>sethover(true)}
+          onMouseOut={()=>sethover(false)}>
+            <Typography variant="h6" {...styles.text.h6}>
+              {props.title}
+            </Typography>
+            <Typography variant="body2" component="p" {...styles.text.p}>
+              {props.body}
+            </Typography>
+          </CardContent>
+        }
       </CardActionArea>
     </Card>
   )

--- a/src/components/molecules/ImageCard/ImageCard.js
+++ b/src/components/molecules/ImageCard/ImageCard.js
@@ -11,6 +11,9 @@ const useStyles = props =>
       background: getColor(props.styles.root.background),
       color: getColor(props.styles.root.color),
       maxWidth: props.styles.root.maxWidth,
+      maxHeight: props.styles.root.maxHeight,
+      width: props.styles.root.width,
+      height: props.styles.root.height,
     },
     img: props.styles.img,
     active: {

--- a/src/components/molecules/ImageCard/defaultStyles.js
+++ b/src/components/molecules/ImageCard/defaultStyles.js
@@ -1,8 +1,11 @@
-import { defaultText, defaultImg, defaultH } from "../../../maps/defaultStyles"
+import { defaultText, defaultImg, defaultH, defaultP } from "../../../maps/defaultStyles"
+import T from "../../theme"
+
 
 const { paddingTop, ...imgProps } = defaultImg
-const { h6, ...textProps } = defaultText
+const { h6, p, ...textProps } = defaultText
 const { color, ...hProps } = defaultH
+const { align, ...pProps } = defaultP
 
 const defaultStyles = {
   root: {
@@ -11,7 +14,11 @@ const defaultStyles = {
     maxWidth: 345,
     maxHeight: "100%",
     width: "",
-    height: "100%",
+    height: "100%"
+  },
+  active: {
+    color: "white",
+    background: T.palette.primary.ligth,
   },
   img: {
     ...imgProps,
@@ -21,6 +28,11 @@ const defaultStyles = {
     h6: {
       color: "textPrimary",
       ...hProps,
+    },
+    p: {
+      color: "textSecondary",
+      align: "",
+      ...pProps,
     },
     ...textProps,
   },

--- a/src/components/molecules/ImageCard/defaultStyles.js
+++ b/src/components/molecules/ImageCard/defaultStyles.js
@@ -17,7 +17,7 @@ const defaultStyles = {
   },
   active: {
     color: "black",
-    background: ""
+    background: "",
   },
   img: {
     ...imgProps,

--- a/src/components/molecules/ImageCard/defaultStyles.js
+++ b/src/components/molecules/ImageCard/defaultStyles.js
@@ -8,7 +8,7 @@ const { align, ...pProps } = defaultP
 
 const defaultStyles = {
   root: {
-    color: "black",
+    color: T.palette.secondary.dark,
     background: "white",
     maxWidth: 345,
     maxHeight: "100%",
@@ -16,8 +16,8 @@ const defaultStyles = {
     height: "100%",
   },
   active: {
-    color: "white",
-    background: T.palette.primary.ligth,
+    color: "black",
+    background: ""
   },
   img: {
     ...imgProps,

--- a/src/components/molecules/ImageCard/defaultStyles.js
+++ b/src/components/molecules/ImageCard/defaultStyles.js
@@ -1,7 +1,6 @@
 import { defaultText, defaultImg, defaultH, defaultP } from "../../../maps/defaultStyles"
 import T from "../../theme"
 
-
 const { paddingTop, ...imgProps } = defaultImg
 const { h6, p, ...textProps } = defaultText
 const { color, ...hProps } = defaultH
@@ -14,7 +13,7 @@ const defaultStyles = {
     maxWidth: 345,
     maxHeight: "100%",
     width: "",
-    height: "100%"
+    height: "100%",
   },
   active: {
     color: "white",


### PR DESCRIPTION
subo estos cambios son para el card holder:
añadí: `const { align, ...pProps } = defaultP` el text.p del card holder.

Puse un hover según el diseño:
![image](https://user-images.githubusercontent.com/12575632/88237514-019b8300-cc45-11ea-8ef0-7eeef4516bef.png)

--
Probe con esta tarjeta de portafolio  el hover:
![image](https://user-images.githubusercontent.com/12575632/88237555-1841da00-cc45-11ea-809f-3203105662b1.png)

![image](https://user-images.githubusercontent.com/12575632/88237565-1d9f2480-cc45-11ea-9fdf-01d82c8e93dc.png)

---
también estate añadiendo en contenful a este card holder información para cambiar el color del body.text y alienar a la izquierda el texto, y propiedades para el hover, en el caso de que no se quiera hover en otras tarjetas.

----
En la sección del hover tengo unos warning  al cambiar a onFocus, onBlur tal y como dice el mensaje el hover no nunca voy probar con alguna otra propiedad. 
```
  32:11  warning  onMouseOver must be accompanied by onFocus for accessibility
jsx-a11y/mouse-events-have-key-events
  32:11  warning  onMouseOut must be accompanied by onBlur for accessibility
jsx-a11y/mouse-events-have-key-events
  42:11  warning  onMouseOver must be accompanied by onFocus for accessibility
jsx-a11y/mouse-events-have-key-events
  42:11  warning  onMouseOut must be accompanied by onBlur for accessibility 
```



