### PR TITLE
Enable Header and Footer position position override

### DIFF
--- a/src/components/organisms/Footer/Footer.js
+++ b/src/components/organisms/Footer/Footer.js
@@ -17,11 +17,12 @@ import { Box, AppBar, Toolbar, Hidden, Typography, Container } from "@material-u
 const useStyles = props =>
   makeStyles(theme => ({
     root: {
+      flexGrow: 1,
       bottom: 0,
       height: props.styles.root.height,
       width: props.styles.root.width,
       top: "auto",
-      position: "relative",
+      position: props.styles.root.position,
       paddingTop: theme.spacing(5),
       background: getColor(props.styles.root.background),
     },

--- a/src/components/organisms/Footer/defaultStyles.js
+++ b/src/components/organisms/Footer/defaultStyles.js
@@ -5,6 +5,7 @@ const defaultStyles = {
     background: T.palette.gradient.ioetOrange,
     height: "20%",
     width: "100%",
+    position: "relative"
   },
 }
 

--- a/src/components/organisms/Header/Header.js
+++ b/src/components/organisms/Header/Header.js
@@ -18,8 +18,9 @@ import { Grid, AppBar, Hidden, Toolbar, Drawer, Container } from "@material-ui/c
 const drawerWidth = 700
 const useStyles = props =>
   makeStyles(theme => ({
-    rootColor: {
+    root: {
       background: getColor(props.styles.root.background),
+      position: props.styles.root.position
     },
     drawer: {
       [theme.breakpoints.up("sm")]: {
@@ -103,7 +104,7 @@ const Header = props => {
   const container = window !== undefined ? () => window().document.body : undefined
 
   const drawer = (
-    <div className={`customDrawer ${classes.rootColor}`}>
+    <div className={`customDrawer ${classes.root}`}>
       <List className="inlineItems">
         {navigationLinks.map((item, index) => (
           <div button="true" key={`drawer-${props.parentSlug}-${item.caption}`}>
@@ -129,7 +130,7 @@ const Header = props => {
 
   return (
     <div className="componentHeader ">
-      <AppBar position="sticky" className={classes.rootColor}>
+      <AppBar className={classes.root}>
         <Container maxWidth="xl">
           <Toolbar>
             <Hidden xsDown>

--- a/src/components/organisms/Header/Header.scss
+++ b/src/components/organisms/Header/Header.scss
@@ -2,6 +2,7 @@
   .iconMenu {
     font-size: 45px;
   }
+  flex-grow: 1;
 }
 .MuiBackdrop-root {
   background-color: transparent !important;

--- a/src/components/organisms/Header/defaultStyles.js
+++ b/src/components/organisms/Header/defaultStyles.js
@@ -3,6 +3,7 @@ import T from "../../theme"
 const defaultStyles = {
   root: {
     background: T.palette.transparent.ioetOrange,
+    position: "sticky",
   },
 }
 


### PR DESCRIPTION
Hi team, please review this PR it adds the ability to override the position changes on the Header and Footer components. Check the [AppBar API](https://material-ui.com/es/api/app-bar/) to see the available position controls.

Closes #33 